### PR TITLE
修复当存在文档组件时，旋转屏幕导致的崩溃问题

### DIFF
--- a/library/src/main/java/com/cz/android/sample/library/component/document/SampleDocumentFragment.java
+++ b/library/src/main/java/com/cz/android/sample/library/component/document/SampleDocumentFragment.java
@@ -35,9 +35,6 @@ public class SampleDocumentFragment extends Fragment {
         return fragment;
     }
 
-    private SampleDocumentFragment(){
-    }
-
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {


### PR DESCRIPTION
# 复现路径

1. 打开 Test ->SampleDocumentFragment 页面；
2. 旋转屏幕。

# 问题原因

由于 Fragment 在恢复状态时，会通过反射去调用默认构造函数，因此如果构造函数被设置为了 private 就会导致反射失败。源码路径：

FragmentManagerImpl#restoreSaveState() -> fs.instantiate() -> factory.instantiate() ->

```
Class<? extends Fragment> cls = loadFragmentClass(classLoader, className);
return cls.getConstructor().newInstance();
```

# 解决方案

删除私有构造函数。