### PR TITLE
Fix recreate failure issue and clean unused code

### DIFF
--- a/core/src/main/java/com/github/jackchen/android/core/appcompat/AbstractSampleActivity.kt
+++ b/core/src/main/java/com/github/jackchen/android/core/appcompat/AbstractSampleActivity.kt
@@ -1,0 +1,38 @@
+package com.github.jackchen.android.core.appcompat
+
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+
+/**
+ * @author airsaid
+ */
+abstract class AbstractSampleActivity : AppCompatActivity() {
+
+  companion object {
+    private const val ANDROID_SUPPORT_FRAGMENTS = "android:support:fragments"
+  }
+
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    // Because if we restart this activity. It will re-create the fragment by FragmentManagerState
+    outState.remove(ANDROID_SUPPORT_FRAGMENTS)
+  }
+
+  /**
+   * If user want to have his own toolbar. we won't add the standard toolbar for sample.
+   */
+  protected fun hasToolBar(view: View): Boolean {
+    if (Toolbar::class.java === view.javaClass) {
+      return true
+    } else if (view is ViewGroup) {
+      for (i in 0 until view.childCount) {
+        val childView = view.getChildAt(i)
+        return hasToolBar(childView)
+      }
+    }
+    return false
+  }
+}

--- a/core/src/main/java/com/github/jackchen/android/core/appcompat/SampleAppCompatActivity.java
+++ b/core/src/main/java/com/github/jackchen/android/core/appcompat/SampleAppCompatActivity.java
@@ -31,9 +31,8 @@ import com.github.jackchen.android.core.main.component.DefaultMainSampleFragment
  * @date 2020-01-28 14:05
  * @email bingo110@126.com
  */
-public class SampleAppCompatActivity extends AppCompatActivity {
+public class SampleAppCompatActivity extends AbstractSampleActivity {
     public static final String BIND_MAIN_SAMPLE_FRAGMENT_TAG = "android_sample_main_fragment";
-    private static final String ANDROID_SUPPORT_FRAGMENTS = "android:support:fragments";
     private AppcompatWindowDelegate windowDelegate;
     /**
      * This is user's original view. However We may change it. or put this view input a fragment
@@ -51,13 +50,6 @@ public class SampleAppCompatActivity extends AppCompatActivity {
      * So we keep this view. If findViewById can't find the view. we try to find view from it
      */
     private View contentView = null;
-
-    @Override
-    protected void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        //Because if we restart this activity. It will re-create the fragment by FragmentManagerState
-        outState.remove(ANDROID_SUPPORT_FRAGMENTS);
-    }
 
     @Override
     public void setContentView(int layout) {
@@ -148,25 +140,6 @@ public class SampleAppCompatActivity extends AppCompatActivity {
             v = contentView.findViewById(id);
         }
         return v;
-    }
-
-    /**
-     * If user want to have his own toolbar. we won't add the standard toolbar for sample
-     *
-     * @param view
-     * @return
-     */
-    private Boolean hasToolBar(View view) {
-        if (Toolbar.class == view.getClass()) {
-            return true;
-        } else if (view instanceof ViewGroup) {
-            ViewGroup viewGroup = (ViewGroup) view;
-            for (int i = 0; i < viewGroup.getChildCount(); i++) {
-                View childView = viewGroup.getChildAt(i);
-                return hasToolBar(childView);
-            }
-        }
-        return false;
     }
 
     /**

--- a/core/src/main/java/com/github/jackchen/android/core/appcompat/SampleFragmentContainerActivity.java
+++ b/core/src/main/java/com/github/jackchen/android/core/appcompat/SampleFragmentContainerActivity.java
@@ -31,7 +31,7 @@ import com.github.jackchen.android.sample.api.SampleItem;
  * @date 2020-01-28 18:00
  * @email bingo110@126.com
  */
-public class SampleFragmentContainerActivity extends AppCompatActivity {
+public class SampleFragmentContainerActivity extends AbstractSampleActivity {
     private static final String SAMPLE_FRAGMENT_TAG = "sample_fragment_tag";
 
     private AppcompatWindowDelegate windowDelegate = new AppcompatWindowDelegate();
@@ -145,24 +145,5 @@ public class SampleFragmentContainerActivity extends AppCompatActivity {
             }
         }
         return fragment;
-    }
-
-    /**
-     * If user want to have his own toolbar. we won't add the standard toolbar for sample
-     *
-     * @param view
-     * @return
-     */
-    private Boolean hasToolBar(View view) {
-        if (Toolbar.class == view.getClass()) {
-            return true;
-        } else if (view instanceof ViewGroup) {
-            ViewGroup viewGroup = (ViewGroup) view;
-            for (int i = 0; i < viewGroup.getChildCount(); i++) {
-                View childView = viewGroup.getChildAt(i);
-                return hasToolBar(childView);
-            }
-        }
-        return false;
     }
 }

--- a/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/visitor/SampleClassVisitor.kt
+++ b/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/visitor/SampleClassVisitor.kt
@@ -10,20 +10,11 @@ class SampleClassVisitor(classVisitor: ClassVisitor?) : ClassVisitor(Opcodes.ASM
         private const val SUPER_CLASS_NAME = "com/github/jackchen/android/core/appcompat/SampleAppCompatActivity"
         private const val ANDROIDX_COMPAT_ACTIVITY_CLASS_NAME = "androidx/appcompat/app/AppCompatActivity"
         private const val ANDROIDX_FRAGMENT_ACTIVITY_CLASS_NAME = "androidx/fragment/app/FragmentActivity"
-        private const val ANDROIDX_FRAGMENT_CLASS_NAME = "androidx/fragment/app/Fragment"
-
-        private val SAMPLE_CLASS_LIST: MutableList<String> = ArrayList()
-
-        init {
-            SAMPLE_CLASS_LIST.add(ANDROIDX_COMPAT_ACTIVITY_CLASS_NAME)
-            SAMPLE_CLASS_LIST.add(ANDROIDX_FRAGMENT_ACTIVITY_CLASS_NAME)
-            SAMPLE_CLASS_LIST.add(ANDROIDX_FRAGMENT_CLASS_NAME)
-        }
     }
+
     private lateinit var superClass: String
     private lateinit var className: String
     private var interfaceArray = emptyArray<String>()
-
 
     override fun visit(
         version: Int, access: Int, name: String,


### PR DESCRIPTION
Details as follows:

1. Fix recreate failure issue: `SampleFragmentContainerActivity` did not handle the recreate issue, so it was added to handle it, and because there was duplicate code, an abstract class was added to reuse the code. 
2. Clean unused code.