### PR TITLE
Fix data inconsistency caused by incremental

### DIFF
--- a/api/src/main/java/com/github/jackchen/android/sample/api/ExtensionItem.java
+++ b/api/src/main/java/com/github/jackchen/android/sample/api/ExtensionItem.java
@@ -1,5 +1,8 @@
 package com.github.jackchen.android.sample.api;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 public class ExtensionItem {
     public String className;
     public String superClass;
@@ -12,5 +15,27 @@ public class ExtensionItem {
         this.className = className;
         this.superClass = superClass;
         this.interfaces = interfaces;
+    }
+
+    @Override
+    public String toString() {
+        return "ExtensionItem{" +
+            "className='" + className + '\'' +
+            ", superClass='" + superClass + '\'' +
+            ", interfaces=" + Arrays.toString(interfaces) +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExtensionItem that = (ExtensionItem) o;
+        return Objects.equals(className, that.className);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(className);
     }
 }

--- a/api/src/main/java/com/github/jackchen/android/sample/api/ExtensionItem.java
+++ b/api/src/main/java/com/github/jackchen/android/sample/api/ExtensionItem.java
@@ -17,6 +17,16 @@ public class ExtensionItem {
         this.interfaces = interfaces;
     }
 
+    public boolean isAvailable() {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            // Ignore
+        }
+        return false;
+    }
+
     @Override
     public String toString() {
         return "ExtensionItem{" +

--- a/api/src/main/java/com/github/jackchen/android/sample/api/SampleItem.java
+++ b/api/src/main/java/com/github/jackchen/android/sample/api/SampleItem.java
@@ -30,7 +30,13 @@ public class SampleItem implements Comparable<SampleItem> {
 
     @Override
     public String toString() {
-        return title;
+        return "SampleItem{" +
+            "title='" + title + '\'' +
+            ", desc='" + desc + '\'' +
+            ", path='" + path + '\'' +
+            ", className='" + className + '\'' +
+            ", isTestCase=" + isTestCase +
+            '}';
     }
 
     @Override public int compareTo(final SampleItem sampleItem) {
@@ -39,16 +45,14 @@ public class SampleItem implements Comparable<SampleItem> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         SampleItem that = (SampleItem) o;
-        return Objects.equals(title, that.title);
+        return Objects.equals(className, that.className);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(title, desc);
+        return Objects.hash(className);
     }
 }

--- a/api/src/main/java/com/github/jackchen/android/sample/api/SampleItem.java
+++ b/api/src/main/java/com/github/jackchen/android/sample/api/SampleItem.java
@@ -28,6 +28,16 @@ public class SampleItem implements Comparable<SampleItem> {
         return null;
     }
 
+    public boolean isAvailable() {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            // Ignore
+        }
+        return false;
+    }
+
     @Override
     public String toString() {
         return "SampleItem{" +

--- a/core/src/main/java/com/github/jackchen/android/core/AndroidSample.kt
+++ b/core/src/main/java/com/github/jackchen/android/core/AndroidSample.kt
@@ -154,7 +154,9 @@ abstract class AndroidSample protected constructor() {
                     sampleItem.path = sampleItem.className.substringBeforeLast(".").replace('.', '/')
                 }
                 sampleItem.isTestCase = sampleObject.getBoolean("isTestCase")
-                sampleItemList.add(sampleItem)
+                if (sampleItem.isAvailable) {
+                    sampleItemList.add(sampleItem)
+                }
             }
             return sampleItemList
         }
@@ -183,7 +185,9 @@ abstract class AndroidSample protected constructor() {
                 extensionItem.interfaces = Array<String>(interfaceArray.length()) { index ->
                     interfaceArray.getString(index)
                 }
-                extensionItemList.add(extensionItem)
+                if (extensionItem.isAvailable) {
+                    extensionItemList.add(extensionItem)
+                }
             }
             return extensionItemList
         }

--- a/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/SamplePlugin.kt
+++ b/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/SamplePlugin.kt
@@ -41,8 +41,6 @@ class SamplePlugin : Plugin<Project> {
     val androidComponentsExtension =
       project.extensions.getByType(AndroidComponentsExtension::class.java)
     androidComponentsExtension.onVariants { variant ->
-      // Clear the data every time when we register the transform.
-      SampleClassHandler.clearData()
       variant.transformClassesWith(
         SampleAsmClassVisitorFactory::class.java,
         InstrumentationScope.PROJECT
@@ -95,8 +93,8 @@ class SamplePlugin : Plugin<Project> {
 
   private fun createSampleConfigurationClass(
     destFolder: File,
-    sampleItemList: MutableList<SampleItem>,
-    extensionList: MutableList<ExtensionItem>
+    sampleItemList: List<SampleItem>,
+    extensionList: List<ExtensionItem>
   ) {
     val configurationJsonText =
       Gson().toJson(mapOf("samples" to sampleItemList, "extensions" to extensionList))

--- a/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/instrumentation/SampleAsmClassVisitorFactory.kt
+++ b/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/instrumentation/SampleAsmClassVisitorFactory.kt
@@ -41,6 +41,7 @@ abstract class SampleAsmClassVisitorFactory :
         return true
       }
     }
+    SampleClassHandler.cleanDirtyData(classData.className)
     return false
   }
 


### PR DESCRIPTION
In incremental scenarios, clearing them all would result in inconsistent data.

So, it is still need to cache the results and clean up in case of mismatch, thus perfectly supporting incremental scenarios.

For the case of deleted classes, runtime checks have been added.