### PR TITLE
Support manual specify of category name and desc

### DIFF
--- a/api/src/main/java/com/github/jackchen/android/sample/api/Register.kt
+++ b/api/src/main/java/com/github/jackchen/android/sample/api/Register.kt
@@ -35,4 +35,20 @@ annotation class Register(
    * based on the package name of the simple class.
    */
   val path: String = "",
+
+  /**
+   * The path title of the [path].
+   *
+   * When specified, the category name of the path will be displayed in the list.
+   * If it is not specified, the name of the most recent [path] will be displayed.
+   */
+  val pathTitle: String = "",
+
+  /**
+   * The path description of the [path].
+   *
+   * When specified, the category desc of the path will be displayed in the list.
+   * If it is not specified, it will not be displayed.
+   */
+  val pathDesc: String = ""
 )

--- a/api/src/main/java/com/github/jackchen/android/sample/api/SampleItem.kt
+++ b/api/src/main/java/com/github/jackchen/android/sample/api/SampleItem.kt
@@ -1,6 +1,6 @@
 package com.github.jackchen.android.sample.api
 
-import java.util.*
+import java.util.Objects
 
 /**
  * @author airsaid
@@ -9,6 +9,8 @@ data class SampleItem(
   var title: String = "",
   var desc: String = "",
   var path: String = "",
+  var pathTitle: String = "",
+  var pathDesc: String = "",
   var className: String = "",
   var isTestCase: Boolean = false,
 ) : Comparable<SampleItem> {

--- a/app/src/main/java/com/github/jackchen/sample/test/SourceCodeSampleActivity.kt
+++ b/app/src/main/java/com/github/jackchen/sample/test/SourceCodeSampleActivity.kt
@@ -14,7 +14,7 @@ import com.github.jackchen.sample.databinding.ActivitySourceCodeSampleBinding
  * @email bingo110@126.com
  * @see SourceCodeView A webView that responsible for demonstrate source code.
  */
-@Register(title = "演示源码加载", desc = "演示源码加载,高度展示")
+@Register(title = "演示源码加载", desc = "演示源码加载,高度展示", pathTitle = "测试", pathDesc = "测试各个组件的使用")
 class SourceCodeSampleActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/core/src/main/java/com/github/jackchen/android/core/SampleConstants.kt
+++ b/core/src/main/java/com/github/jackchen/android/core/SampleConstants.kt
@@ -7,6 +7,8 @@ object SampleConstants {
   const val PARAMETER_TITLE = "title"
   const val PARAMETER_DESC = "desc"
   const val PARAMETER_PATH = "path"
+  const val PARAMETER_PATH_TITLE = "pathTitle"
+  const val PARAMETER_PATH_DESC = "pathDesc"
   const val PARAMETER_FRAGMENT_CLASS = "fragment_class"
   const val SAMPLE_CONFIGURATION_FILE_NAME = "sample_configuration.json"
   const val SAMPLE_CONFIGURATION_CLASS = "com.github.jackchen.android.core.SampleConfiguration"

--- a/core/src/main/java/com/github/jackchen/android/core/main/adapter/SampleListAdapter.kt
+++ b/core/src/main/java/com/github/jackchen/android/core/main/adapter/SampleListAdapter.kt
@@ -6,6 +6,8 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.github.jackchen.android.core.AndroidSample
 import com.github.jackchen.android.core.databinding.SampleListItemBinding
+import com.github.jackchen.android.core.util.displayDesc
+import com.github.jackchen.android.core.util.displayTitle
 import com.github.jackchen.android.sample.api.SampleItem
 
 /**
@@ -36,19 +38,19 @@ class SampleListAdapter(items: MutableList<AndroidSample.PathNode>) :
 
   class ViewHolder(private val binding: SampleListItemBinding) : RecyclerView.ViewHolder(binding.root) {
     fun bind(node: AndroidSample.PathNode) {
+      binding.sampleTitle.text = node.displayTitle()
+      val desc = node.displayDesc()
+      if (desc.isNotEmpty()) {
+        binding.sampleDescription.text = desc
+        binding.sampleDescription.visibility = View.VISIBLE
+      } else {
+        binding.sampleDescription.visibility = View.GONE
+      }
+
       val item = node.item
       if (item is String) {
-        binding.sampleTitle.text = item.replaceFirstChar { it.uppercaseChar() }
-        binding.sampleDescription.visibility = View.GONE
         binding.sampleImageArrow.visibility = View.VISIBLE
       } else if (item is SampleItem) {
-        binding.sampleTitle.text = item.title?.replaceFirstChar { it.uppercaseChar() }
-        if (item.desc.isNotEmpty()) {
-          binding.sampleDescription.text = item.desc
-          binding.sampleDescription.visibility = View.VISIBLE
-        } else {
-          binding.sampleDescription.visibility = View.GONE
-        }
         binding.sampleImageArrow.visibility = View.GONE
       }
     }

--- a/core/src/main/java/com/github/jackchen/android/core/main/component/DefaultMainSampleFragment.kt
+++ b/core/src/main/java/com/github/jackchen/android/core/main/component/DefaultMainSampleFragment.kt
@@ -3,7 +3,13 @@ package com.github.jackchen.android.core.main.component
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.view.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
@@ -17,6 +23,8 @@ import com.github.jackchen.android.core.SampleConstants
 import com.github.jackchen.android.core.databinding.SampleFragmentMainLayoutBinding
 import com.github.jackchen.android.core.main.adapter.MutableListAdapter
 import com.github.jackchen.android.core.main.adapter.SampleListAdapter
+import com.github.jackchen.android.core.util.displayDesc
+import com.github.jackchen.android.core.util.displayTitle
 import com.github.jackchen.android.sample.api.SampleItem
 
 /**
@@ -95,7 +103,8 @@ class DefaultMainSampleFragment : Fragment() {
         if (null != activityClass) {
           val clazz = Class.forName(activityClass)
           Intent(requireActivity(), clazz).apply {
-            putExtra(SampleConstants.PARAMETER_TITLE, category)
+            putExtra(SampleConstants.PARAMETER_TITLE, pathNode.displayTitle())
+            putExtra(SampleConstants.PARAMETER_DESC, pathNode.displayDesc())
             putExtra(SampleConstants.PARAMETER_PATH, subDirectory)
             startActivity(this)
           }

--- a/core/src/main/java/com/github/jackchen/android/core/path/PathInfo.kt
+++ b/core/src/main/java/com/github/jackchen/android/core/path/PathInfo.kt
@@ -1,0 +1,10 @@
+package com.github.jackchen.android.core.path
+
+/**
+ * @author airsaid
+ */
+data class PathInfo(
+  val path: String,
+  val pathTitle: String,
+  val pathDesc: String,
+)

--- a/core/src/main/java/com/github/jackchen/android/core/path/PathProvider.kt
+++ b/core/src/main/java/com/github/jackchen/android/core/path/PathProvider.kt
@@ -1,0 +1,24 @@
+package com.github.jackchen.android.core.path
+
+import com.github.jackchen.android.sample.api.SampleItem
+
+/**
+ * @author airsaid
+ */
+object PathProvider {
+
+  private val mPathMap = hashMapOf<String, PathInfo>()
+
+  fun init(samples: List<SampleItem>) {
+    samples.forEach { item ->
+      val oldPath = mPathMap[item.path]
+      val newPath = PathInfo(item.path, item.pathTitle, item.pathDesc)
+      if (oldPath != newPath) {
+        mPathMap[item.path] = newPath
+      }
+    }
+  }
+
+  fun getPathMap(): HashMap<String, PathInfo> = mPathMap
+
+}

--- a/core/src/main/java/com/github/jackchen/android/core/util/PathNodes.kt
+++ b/core/src/main/java/com/github/jackchen/android/core/util/PathNodes.kt
@@ -1,0 +1,30 @@
+package com.github.jackchen.android.core.util
+
+import com.github.jackchen.android.core.AndroidSample
+import com.github.jackchen.android.core.path.PathProvider
+import com.github.jackchen.android.sample.api.SampleItem
+
+fun AndroidSample.PathNode.displayTitle(): String {
+  val nodeItem = item
+  if (nodeItem is SampleItem) {
+    return nodeItem.title.replaceFirstChar { it.uppercaseChar() }
+  }
+  val itemStr = nodeItem.toString()
+  val pathMap = PathProvider.getPathMap()
+  val pathInfo = pathMap[fullPath]
+  return if (pathInfo != null && pathInfo.pathTitle.isNotEmpty()) {
+    pathInfo.pathTitle
+  } else {
+    itemStr.replaceFirstChar { it.uppercaseChar() }
+  }
+}
+
+fun AndroidSample.PathNode.displayDesc(): String {
+  val nodeItem = item
+  if (nodeItem is SampleItem) {
+    return nodeItem.desc
+  }
+  val pathMap = PathProvider.getPathMap()
+  val pathInfo = pathMap[fullPath]
+  return pathInfo?.pathDesc ?: ""
+}

--- a/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/visitor/annotaiton/ComponentAnnotationHandler.kt
+++ b/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/visitor/annotaiton/ComponentAnnotationHandler.kt
@@ -25,6 +25,8 @@ class ComponentAnnotationHandler : AnnotationHandler() {
       "title" -> sampleItem?.title = value.toString()
       "desc" -> sampleItem?.desc = value.toString()
       "path" -> sampleItem?.path = value.toString()
+      "pathTitle" -> sampleItem?.pathTitle = value.toString()
+      "pathDesc" -> sampleItem?.pathDesc = value.toString()
     }
   }
 }


### PR DESCRIPTION
Since it is currently not possible to manually specify the title and description information for a category, a function has been added that allows you to manually specify this information. 

When not specified, the function is the same as before.