### PR TITLE
Refactor the sample plugin.

### DIFF
--- a/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/instrumentation/SampleAsmClassVisitorFactory.kt
+++ b/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/instrumentation/SampleAsmClassVisitorFactory.kt
@@ -4,6 +4,7 @@ import com.android.build.api.instrumentation.AsmClassVisitorFactory
 import com.android.build.api.instrumentation.ClassContext
 import com.android.build.api.instrumentation.ClassData
 import com.android.build.api.instrumentation.InstrumentationParameters
+import com.android.build.gradle.internal.instrumentation.ClassContextImpl
 import com.github.jackchen.android.sample.api.Extension
 import com.github.jackchen.android.sample.api.Register
 import com.github.jackchen.android.sample.api.TestCase
@@ -28,7 +29,9 @@ abstract class SampleAsmClassVisitorFactory :
     classContext: ClassContext,
     nextClassVisitor: ClassVisitor
   ): ClassVisitor {
-    return SampleClassVisitor(nextClassVisitor)
+    val classContextImpl = classContext as ClassContextImpl
+    val classesHierarchyResolver = classContextImpl.classesHierarchyResolver
+    return SampleClassVisitor(nextClassVisitor, classesHierarchyResolver)
   }
 
   override fun isInstrumentable(classData: ClassData): Boolean {
@@ -41,7 +44,6 @@ abstract class SampleAsmClassVisitorFactory :
         return true
       }
     }
-    SampleClassHandler.cleanDirtyData(classData.className)
     return false
   }
 

--- a/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/instrumentation/SampleAsmClassVisitorFactory.kt
+++ b/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/instrumentation/SampleAsmClassVisitorFactory.kt
@@ -4,7 +4,6 @@ import com.android.build.api.instrumentation.AsmClassVisitorFactory
 import com.android.build.api.instrumentation.ClassContext
 import com.android.build.api.instrumentation.ClassData
 import com.android.build.api.instrumentation.InstrumentationParameters
-import com.android.build.gradle.internal.instrumentation.ClassContextImpl
 import com.github.jackchen.android.sample.api.Extension
 import com.github.jackchen.android.sample.api.Register
 import com.github.jackchen.android.sample.api.TestCase
@@ -29,9 +28,7 @@ abstract class SampleAsmClassVisitorFactory :
     classContext: ClassContext,
     nextClassVisitor: ClassVisitor
   ): ClassVisitor {
-    val classContextImpl = classContext as ClassContextImpl
-    val classesHierarchyResolver = classContextImpl.classesHierarchyResolver
-    return SampleClassVisitor(nextClassVisitor, classesHierarchyResolver)
+    return SampleClassVisitor(nextClassVisitor)
   }
 
   override fun isInstrumentable(classData: ClassData): Boolean {

--- a/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/instrumentation/SampleClassHandler.kt
+++ b/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/instrumentation/SampleClassHandler.kt
@@ -2,6 +2,7 @@ package com.github.jackchen.plugin.sample.instrumentation
 
 import com.github.jackchen.android.sample.api.ExtensionItem
 import com.github.jackchen.android.sample.api.SampleItem
+import com.github.jackchen.plugin.sample.task.ClassConfigurations
 import com.github.jackchen.plugin.sample.visitor.SampleClassVisitor
 import com.github.jackchen.plugin.sample.visitor.annotaiton.AnnotationHandler
 import com.github.jackchen.plugin.sample.visitor.annotaiton.ComponentAnnotationHandler
@@ -55,22 +56,18 @@ object SampleClassHandler {
     return sampleAnnotationHandlerList.find { it.accept(classVisitor, desc, visible) }
   }
 
+  fun loadDataFromCache(classConfigurations: ClassConfigurations) {
+    sampleMap.clear()
+    classConfigurations.samples.forEach { sampleItem ->
+      sampleMap[sampleItem.className] = sampleItem
+    }
+    extensionMap.clear()
+    classConfigurations.extensions.forEach { extensionItem ->
+      extensionMap[extensionItem.className] = extensionItem
+    }
+  }
+
   fun getSampleList(): List<SampleItem> = sampleMap.values.toList()
 
   fun getExtensionList(): List<ExtensionItem> = extensionMap.values.toList()
-
-  /**
-   * For incremental scenarios, if the new class no longer matches,
-   * it needs to be removed from the list to avoid generating dirty data.
-   *
-   * @param notMatchClassName Class names that do not conform to the processing rules.
-   */
-  fun cleanDirtyData(notMatchClassName: String) {
-    if (sampleMap.containsKey(notMatchClassName)) {
-      sampleMap.remove(notMatchClassName)
-    }
-    if (extensionMap.containsKey(notMatchClassName)) {
-      extensionMap.remove(notMatchClassName)
-    }
-  }
 }

--- a/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/task/ClassConfigurations.kt
+++ b/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/task/ClassConfigurations.kt
@@ -1,0 +1,9 @@
+package com.github.jackchen.plugin.sample.task
+
+import com.github.jackchen.android.sample.api.ExtensionItem
+import com.github.jackchen.android.sample.api.SampleItem
+
+class ClassConfigurations(
+  val samples: List<SampleItem>,
+  val extensions: List<ExtensionItem>
+)

--- a/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/task/PostTransformClassesWithAsmTask.kt
+++ b/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/task/PostTransformClassesWithAsmTask.kt
@@ -1,0 +1,77 @@
+package com.github.jackchen.plugin.sample.task
+
+import com.github.jackchen.android.sample.api.ExtensionItem
+import com.github.jackchen.android.sample.api.SampleItem
+import com.github.jackchen.plugin.sample.PathNodePrinter
+import com.github.jackchen.plugin.sample.instrumentation.AndroidSampleTemplateCreator
+import com.github.jackchen.plugin.sample.instrumentation.SampleClassHandler
+import com.google.gson.Gson
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+abstract class PostTransformClassesWithAsmTask : DefaultTask() {
+  companion object {
+    const val TASK_NAME = "postTransformClassesWithAsm"
+  }
+
+  @get:Input
+  abstract val outputDebugLogProvider: Property<Boolean>
+
+  @get:Input
+  abstract val transformOutputsProvider: ListProperty<File>
+
+  @get:OutputFile
+  abstract val configurationOutputFileProvider: RegularFileProperty
+
+  init {
+    outputDebugLogProvider.convention(false)
+    configurationOutputFileProvider.set(
+      File(
+        project.buildDir,
+        "intermediates/$TASK_NAME/output"
+      )
+    )
+  }
+
+  @TaskAction
+  fun postTransformClassesWithAsm() {
+    if (!transformOutputsProvider.isPresent) return
+    val transformOutputDirs = transformOutputsProvider.get()
+    val classFileList =
+      transformOutputDirs.flatMap { it.walk().filter { classFile -> classFile.name.endsWith(".class") } }
+    val sampleList = SampleClassHandler.getSampleList().toMutableList()
+    sampleList.removeIf { item ->
+      val classPath = item.className.replace('.', '/')
+      classFileList.none { it.absolutePath.endsWith("$classPath.class") }
+    }
+    val extensionList = SampleClassHandler.getExtensionList().toMutableList()
+    extensionList.removeIf { item ->
+      val classPath = item.className.replace('.', '/')
+      classFileList.none { it.absolutePath.endsWith("$classPath.class") }
+    }
+    if (transformOutputDirs.isNotEmpty()) {
+      val destFolder = transformOutputDirs.first()
+      val newClassConfigurations = ClassConfigurations(sampleList, extensionList)
+      createSampleConfigurationClass(destFolder, newClassConfigurations)
+    }
+    if (outputDebugLogProvider.get()) {
+      PathNodePrinter.printPathTree(sampleList)
+    }
+  }
+
+  private fun createSampleConfigurationClass(
+    destFolder: File,
+    newClassConfigurations: ClassConfigurations
+  ) {
+    val configurationJsonText = Gson().toJson(newClassConfigurations)
+    val regularFile = configurationOutputFileProvider.get()
+    regularFile.asFile.writeText(configurationJsonText)
+    AndroidSampleTemplateCreator.create(destFolder, configurationJsonText)
+  }
+}

--- a/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/task/PreTransformClassesWithAsmTask.kt
+++ b/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/task/PreTransformClassesWithAsmTask.kt
@@ -1,0 +1,38 @@
+package com.github.jackchen.plugin.sample.task
+
+import com.github.jackchen.plugin.sample.instrumentation.SampleClassHandler
+import com.google.gson.Gson
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+abstract class PreTransformClassesWithAsmTask : DefaultTask() {
+  companion object {
+    const val TASK_NAME = "preTransformClassesWithAsm"
+  }
+
+  @get:OutputFile
+  abstract val configurationOutputFileProvider: RegularFileProperty
+
+  init {
+    configurationOutputFileProvider.set(
+      File(
+        project.buildDir,
+        "intermediates/$TASK_NAME/output"
+      )
+    )
+  }
+
+  @TaskAction
+  fun postTransformClassesWithAsm() {
+    val regularFile = configurationOutputFileProvider.get()
+    val configurationOutputFile = regularFile.asFile
+    if (configurationOutputFile.exists()) {
+      val configurationOutputCaching = configurationOutputFile.readText()
+      val classConfigurations = Gson().fromJson(configurationOutputCaching, ClassConfigurations::class.java)
+      SampleClassHandler.loadDataFromCache(classConfigurations)
+    }
+  }
+}

--- a/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/visitor/SampleClassVisitor.kt
+++ b/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/visitor/SampleClassVisitor.kt
@@ -1,6 +1,5 @@
 package com.github.jackchen.plugin.sample.visitor
 
-import com.android.build.gradle.internal.instrumentation.ClassesHierarchyResolver
 import com.github.jackchen.plugin.sample.instrumentation.SampleClassHandler
 import org.objectweb.asm.AnnotationVisitor
 import org.objectweb.asm.ClassVisitor
@@ -9,10 +8,7 @@ import org.objectweb.asm.Opcodes
 /**
  * @author JackChen
  */
-class SampleClassVisitor(
-  classVisitor: ClassVisitor?,
-  private val classesHierarchyResolver: ClassesHierarchyResolver
-) : ClassVisitor(Opcodes.ASM6, classVisitor) {
+class SampleClassVisitor(classVisitor: ClassVisitor?) : ClassVisitor(Opcodes.ASM6, classVisitor) {
   companion object {
     private const val SUPER_CLASS_NAME = "com/github/jackchen/android/core/appcompat/SampleAppCompatActivity"
     const val ANDROIDX_COMPAT_ACTIVITY_CLASS_NAME = "androidx/appcompat/app/AppCompatActivity"

--- a/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/visitor/SampleClassVisitor.kt
+++ b/sample-plugin/src/main/java/com/github/jackchen/plugin/sample/visitor/SampleClassVisitor.kt
@@ -1,5 +1,6 @@
 package com.github.jackchen.plugin.sample.visitor
 
+import com.android.build.gradle.internal.instrumentation.ClassesHierarchyResolver
 import com.github.jackchen.plugin.sample.instrumentation.SampleClassHandler
 import org.objectweb.asm.AnnotationVisitor
 import org.objectweb.asm.ClassVisitor
@@ -8,7 +9,10 @@ import org.objectweb.asm.Opcodes
 /**
  * @author JackChen
  */
-class SampleClassVisitor(classVisitor: ClassVisitor?) : ClassVisitor(Opcodes.ASM6, classVisitor) {
+class SampleClassVisitor(
+  classVisitor: ClassVisitor?,
+  private val classesHierarchyResolver: ClassesHierarchyResolver
+) : ClassVisitor(Opcodes.ASM6, classVisitor) {
   companion object {
     private const val SUPER_CLASS_NAME = "com/github/jackchen/android/core/appcompat/SampleAppCompatActivity"
     const val ANDROIDX_COMPAT_ACTIVITY_CLASS_NAME = "androidx/appcompat/app/AppCompatActivity"

--- a/sample-plugin/src/test/kotlin/com/github/jackchen/plugin/sample/SamplePluginTest.kt
+++ b/sample-plugin/src/test/kotlin/com/github/jackchen/plugin/sample/SamplePluginTest.kt
@@ -9,6 +9,7 @@ import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import java.io.File
 import kotlin.math.absoluteValue
 import kotlin.random.Random
 
@@ -169,18 +170,19 @@ class SamplePluginTest : GradlePluginTest() {
         testProjectRunner.projectDir,
         testProjectRunner.testVersions.supportedGradleVersion
       )
+      File(projectDir, "app/src/main/kotlin/com/android/test").deleteRecursively()
       module("app") {
         kotlinSourceDir("com.android.test") {
-          // New file
-          val testMethod = "testMethod${Random.nextInt().absoluteValue}"
-          file("TestDialog2.kt") {
+          // New file with new method. So we always remove an old file and add a new class file to test the incremental change.
+          val newClassName = "TestDialog${Random.nextInt().absoluteValue}"
+          file("$newClassName.kt") {
             """
               |package com.android.test
               |import androidx.appcompat.app.AppCompatDialog
-              |@com.github.jackchen.android.sample.api.Register(title="The test dialog2")
-              |class TestDialog2{
-              |   fun $testMethod(){
-              |     println("$testMethod")
+              |@com.github.jackchen.android.sample.api.Register(title="The test $newClassName")
+              |class $newClassName{
+              |   fun testMethod(){
+              |     println("testMethod")
               |   }
               |}
             """.trimMargin()


### PR DESCRIPTION
### Main changes

* Add a `PreTransformClassesWithAsmTask` to read cache from `PostTransformClassesWithAsmTask`
* Generate configuration cache and write it to an intermediate file.

Use `TransformClassesWithAsm` outputs to determine which class is deleted.

```
    val transformOutputDirs = transformOutputsProvider.get()
    val classFileList =
      transformOutputDirs.flatMap { it.walk().filter { classFile -> classFile.name.endsWith(".class") } }
    val sampleList = SampleClassHandler.getSampleList().toMutableList()
    sampleList.removeIf { item ->
      val classPath = item.className.replace('.', '/')
      classFileList.none { it.absolutePath.endsWith("$classPath.class") }
    }
    val extensionList = SampleClassHandler.getExtensionList().toMutableList()
    extensionList.removeIf { item ->
      val classPath = item.className.replace('.', '/')
      classFileList.none { it.absolutePath.endsWith("$classPath.class") }
    }
```

* Move all the configuration-related code into `PostTransformClassesWithAsmTask`

### How to test it

```
Run `test plugin with incremental` method at least twice to check the output result.
```